### PR TITLE
Add transaction CRUD

### DIFF
--- a/app/Http/Controllers/Api/TransactionController.php
+++ b/app/Http/Controllers/Api/TransactionController.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Repositories\TransactionRepo;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Log;
+
+class TransactionController extends Controller
+{
+    private $transactionRepo;
+    public function __construct(TransactionRepo $transactionRepo) {
+        $this->transactionRepo = $transactionRepo;
+    }
+    /**
+     * @group Transaction
+     * Get
+     *
+     * all
+     */
+    public function all() {
+        try { $transaction = $this->transactionRepo->all();
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Transaction Obtained Correctly'),
+                'data'    => $transaction,
+            ];
+            return response()->json($response, 200);
+        } catch (\Exception $ex) {
+            Log::error($ex);
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+    /**
+     * @group Transaction
+     * Get
+     *
+     * all active
+     */
+    public function allActive() {
+        try { $transaction = $this->transactionRepo->allActive();
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Data Obtained Correctly'),
+                'data'    => $transaction,
+            ];
+            return response()->json($response, 200);
+        } catch (\Exception $ex) {
+            Log::error($ex);
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+    /**
+     * @group Transaction
+     * Get
+     * @urlParam id integer required The ID of the transaction. Example: 1
+     *
+     * find
+     */
+    public function find($id) {
+        try {
+            $transaction = $this->transactionRepo->find($id);
+            if (isset($transaction->id)) {
+                $response = [
+                    'status'  => 'OK',
+                    'code'    => 200,
+                    'message' => __('Transaction Obtained Correctly'),
+                    'data'    => $transaction,
+                ];
+                return response()->json($response, 200);
+            }
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 404,
+                'message' => __('Not Data with this Transaction') . '.',
+            ];
+            return response()->json($response, 200);
+        } catch (\Exception $ex) {
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+    /**
+     * @group Transaction
+     * Post
+     *
+     * save
+     * @bodyParam name string required The name of the transaction. Example: Payment
+     * @bodyParam amount number required The amount. Example: 100.50
+     * @bodyParam description string optional The description. Example: invoice payment
+     * @bodyParam date datetime required The date of the transaction. Example: 2025-07-14 12:00:00
+     * @bodyParam provider_id integer optional The ID of the provider. Example: 1
+     * @bodyParam url_file string optional File URL. Example: https://example.com/file.pdf
+     * @bodyParam rate_id integer optional The rate id. Example: 1
+     * @bodyParam amount_tax number optional The tax amount. Example: 10.00
+     */
+    public function save(Request $request) {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|max:100',
+            'amount' => 'required|numeric',
+            'description' => 'max:255',
+            'date' => 'required|date',
+            'provider_id' => 'nullable|exists:providers,id',
+            'url_file' => 'nullable|string',
+            'rate_id' => 'nullable|integer',
+            'amount_tax' => 'nullable|numeric',
+        ], $this->custom_message());
+        if ($validator->fails()) {
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 400,
+                'message' => __('Incorrect Params'),
+                'data'    => $validator->errors()->getMessages(),
+            ];
+            return response()->json($response);
+        }
+        try {
+            $data = [
+                'name'=> $request->input('name'),
+                'amount'=> $request->input('amount'),
+                'description'=> $request->input('description'),
+                'date'=> $request->input('date'),
+                'provider_id'=> $request->input('provider_id'),
+                'url_file'=> $request->input('url_file'),
+                'rate_id'=> $request->input('rate_id'),
+                'amount_tax'=> $request->input('amount_tax'),
+            ];
+            $transaction= $this->transactionRepo->store($data);
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Transaction saved correctly'),
+                'data'    => $transaction,
+            ];
+            return response()->json($response, 200);
+        } catch (\Exception $ex) {
+            Log::error($ex);
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+    /**
+     * @group Transaction
+     * Put
+     *
+     * update
+     * @urlParam id integer required The ID of the transaction. Example: 1
+     */
+    public function update(Request $request, $id) {
+        $transaction = $this->transactionRepo->find($id);
+        if (isset($transaction->id)) {
+            $data= array();
+            if ($request->has('name')) { $data['name'] = $request->input('name'); }
+            if ($request->has('amount')) { $data['amount'] = $request->input('amount'); }
+            if ($request->has('description')) { $data['description'] = $request->input('description'); }
+            if ($request->has('date')) { $data['date'] = $request->input('date'); }
+            if ($request->has('provider_id')) { $data['provider_id'] = $request->input('provider_id'); }
+            if ($request->has('url_file')) { $data['url_file'] = $request->input('url_file'); }
+            if ($request->has('rate_id')) { $data['rate_id'] = $request->input('rate_id'); }
+            if ($request->has('amount_tax')) { $data['amount_tax'] = $request->input('amount_tax'); }
+            $transaction = $this->transactionRepo->update($transaction, $data);
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Transaction updated'),
+                'data'    => $transaction,
+            ];
+            return response()->json($response, 200);
+        }
+        $response = [
+            'status'  => 'FAILED',
+            'code'    => 500,
+            'message' => __('Transaction dont exists') . '.',
+        ];
+        return response()->json($response, 500);
+    }
+    /**
+     * @group Transaction
+     * Delete
+     * @urlParam id integer required The ID of the transaction. Example: 1
+     *
+     * delete
+     */
+    public function delete(Request $request, $id) {
+        try {
+            if ($this->transactionRepo->find($id)) {
+                $transaction = $this->transactionRepo->find($id);
+                $transaction = $this->transactionRepo->delete($transaction, ['active' => 0]);
+                $transaction = $transaction->delete();
+                $response = [
+                    'status'  => 'OK',
+                    'code'    => 200,
+                    'message' => __('Transaction Deleted Successfully'),
+                    'data'    => $transaction,
+                ];
+                return response()->json($response, 200);
+            }
+            else {
+                $response = [
+                    'status'  => 'OK',
+                    'code'    => 404,
+                    'message' => __('Transaction not Found'),
+                ];
+                return response()->json($response, 200);
+            }
+
+        } catch (\Exception $ex) {
+            Log::error($ex);
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+/**
+     * @group Transaction
+     * Patch
+     * @urlParam id integer required The ID of the transaction. Example: 1
+     *
+     * change_status
+     */
+    public function change_status(Request $request, $id) {
+
+        $transaction = $this->transactionRepo->find($id);
+        if (isset($transaction->active)) {
+            if($transaction->active == 0){
+                $data = ['active' => 1];
+            }else{
+                $data = ['active' => 0];
+            }
+            $transaction = $this->transactionRepo->update($transaction, $data);
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Status Transaction updated'),
+                'data'    => $transaction,
+            ];
+            return response()->json($response, 200);
+        }
+        $response = [
+            'status'  => 'FAILED',
+            'code'    => 500,
+            'message' => __('Transaction does not exist') . '.',
+        ];
+        return response()->json($response, 500);
+    }
+    /**
+     * @group Transaction
+     * Get
+     *
+     * withTrashed
+     */
+     public function withTrashed() {
+        try { $transaction = $this->transactionRepo->withTrashed();
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Data Obtained Correctly'),
+                'data'    => $transaction,
+            ];
+            return response()->json($response, 200);
+        } catch (\Exception $ex) {
+            Log::error($ex);
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+    public function custom_message() {
+
+        return [
+            'name.required'=> __('The name is required'),
+            'amount.required'=> __('The amount is required'),
+            'date.required'=> __('The date is required'),
+        ];
+    }
+}

--- a/app/Models/Entities/Provider.php
+++ b/app/Models/Entities/Provider.php
@@ -5,6 +5,7 @@ namespace App\Models\Entities;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Entities\Transaction;
 
 class Provider extends Model
 {
@@ -24,4 +25,8 @@ class Provider extends Model
         'deleted_at' => 'datetime:Y-m-d',
     ];
 
+    public function transactions()
+    {
+        return $this->hasMany(Transaction::class);
+    }
 }

--- a/app/Models/Entities/Transaction.php
+++ b/app/Models/Entities/Transaction.php
@@ -5,6 +5,7 @@ namespace App\Models\Entities;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Entities\Provider;
 
 class Transaction extends Model
 {
@@ -30,4 +31,9 @@ class Transaction extends Model
         'deleted_at' => 'datetime:Y-m-d',
         'date'       => 'datetime:Y-m-d H:i:s',
     ];
+
+    public function provider()
+    {
+        return $this->belongsTo(Provider::class);
+    }
 }

--- a/app/Models/Entities/Transaction.php
+++ b/app/Models/Entities/Transaction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Notifications\Notifiable;
+
+class Transaction extends Model
+{
+    use SoftDeletes;
+    use Notifiable;
+
+    protected $fillable = [
+        'name',
+        'amount',
+        'description',
+        'date',
+        'active',
+        'deleted_at',
+        'provider_id',
+        'url_file',
+        'rate_id',
+        'amount_tax',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime:Y-m-d',
+        'updated_at' => 'datetime:Y-m-d',
+        'deleted_at' => 'datetime:Y-m-d',
+        'date'       => 'datetime:Y-m-d H:i:s',
+    ];
+}

--- a/app/Models/Repositories/TransactionRepo.php
+++ b/app/Models/Repositories/TransactionRepo.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models\Repositories;
+
+use Illuminate\Support\Facades\Log;
+use App\Models\Entities\Transaction;
+
+class TransactionRepo {
+    public function all() {
+        return Transaction::whereIn('active', [1,0])->with([])->get();
+    }
+    public function allActive() {
+        return Transaction::where('active', 1)->with([])->get();
+    }
+    public function find($id) {
+        return Transaction::with([])->find($id);
+    }
+    public function store($data) {
+        $transaction = new Transaction();
+        $transaction->fill($data);
+        $transaction->save();
+        return $transaction;
+    }
+    public function update($transaction, $data) {
+        $transaction->fill($data);
+        $transaction->save();
+        return $transaction;
+    }
+    public function delete($transaction, $data) {
+        $transaction->fill($data);
+        $transaction->save();
+        return $transaction;
+    }
+    public function withTrashed() {
+        return Transaction::withTrashed()->get();
+    }
+}

--- a/app/Models/Repositories/TransactionRepo.php
+++ b/app/Models/Repositories/TransactionRepo.php
@@ -7,13 +7,13 @@ use App\Models\Entities\Transaction;
 
 class TransactionRepo {
     public function all() {
-        return Transaction::whereIn('active', [1,0])->with([])->get();
+        return Transaction::whereIn('active', [1,0])->with(['provider'])->get();
     }
     public function allActive() {
-        return Transaction::where('active', 1)->with([])->get();
+        return Transaction::where('active', 1)->with(['provider'])->get();
     }
     public function find($id) {
-        return Transaction::with([])->find($id);
+        return Transaction::with(['provider'])->find($id);
     }
     public function store($data) {
         $transaction = new Transaction();

--- a/database/migrations/2025_07_14_120000_create_transactions_table.php
+++ b/database/migrations/2025_07_14_120000_create_transactions_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('transactions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->decimal('amount', 10, 2);
+            $table->string('description')->nullable();
+            $table->dateTime('date');
+            $table->boolean('active')->default(true);
+            $table->unsignedBigInteger('provider_id')->nullable();
+            $table->string('url_file')->nullable();
+            $table->unsignedBigInteger('rate_id')->nullable();
+            $table->decimal('amount_tax', 10, 2)->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->foreign('provider_id')->references('id')->on('providers');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('transactions');
+    }
+};

--- a/routes/api/transactions.php
+++ b/routes/api/transactions.php
@@ -1,0 +1,19 @@
+<?php
+
+  use Illuminate\Support\Facades\Route;
+  use App\Http\Controllers\Api\TransactionController;
+
+  Route::group([
+    'middleware' => ['api'],
+    'prefix'     => 'transactions',
+], function () {
+  //Transaction ROUTES
+    Route::post('/', [TransactionController::class, 'save']);
+    Route::get('/{id}', [TransactionController::class, 'find']);
+    Route::put('/{id}', [TransactionController::class, 'update']);
+    Route::get('/', [TransactionController::class, 'all']);
+    Route::patch('/{id}/status', [TransactionController::class, 'change_status']);
+    Route::get('/active', [TransactionController::class, 'allActive']);
+    Route::delete('/{id}', [TransactionController::class, 'delete']);
+    Route::get('/all', [TransactionController::class, 'withTrashed']);
+  });


### PR DESCRIPTION
## Summary
- add migration for `transactions` table
- add `Transaction` model
- add repository for transactions
- add controller with standard CRUD methods
- register transaction routes

## Testing
- `composer test` *(fails: BadMethodCallException and MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_6876c53c7b64832da570ec86946ffc88