### PR TITLE
Add Venezuelan taxes to seeder

### DIFF
--- a/app/Http/Controllers/Api/TaxController.php
+++ b/app/Http/Controllers/Api/TaxController.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Repositories\TaxRepo;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Log;
+
+class TaxController extends Controller
+{
+    private $TaxRepo;
+
+    public function __construct(TaxRepo $TaxRepo)
+    {
+        $this->TaxRepo = $TaxRepo;
+    }
+
+    /**
+     * @group Tax
+     * Get
+     *
+     * all
+     */
+    public function all()
+    {
+        try {
+            $tax = $this->TaxRepo->all();
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Tax Obtained Correctly'),
+                'data'    => $tax,
+            ];
+            return response()->json($response, 200);
+        } catch (\Exception $ex) {
+            Log::error($ex);
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+
+    /**
+     * @group Tax
+     * Get
+     *
+     * all active
+     */
+    public function allActive()
+    {
+        try {
+            $tax = $this->TaxRepo->allActive();
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Data Obtained Correctly'),
+                'data'    => $tax,
+            ];
+            return response()->json($response, 200);
+        } catch (\Exception $ex) {
+            Log::error($ex);
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+
+    /**
+     * @group Tax
+     * Get
+     * @urlParam id integer required The ID of the tax. Example: 1
+     *
+     * find
+     */
+    public function find($id)
+    {
+        try {
+            $tax = $this->TaxRepo->find($id);
+            if (isset($tax->id)) {
+                $response = [
+                    'status'  => 'OK',
+                    'code'    => 200,
+                    'message' => __('Tax Obtained Correctly'),
+                    'data'    => $tax,
+                ];
+                return response()->json($response, 200);
+            }
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 404,
+                'message' => __('Not Data with this Tax') . '.',
+            ];
+            return response()->json($response, 200);
+        } catch (\Exception $ex) {
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+
+    /**
+     * @group Tax
+     * Post
+     *
+     * save
+     * @bodyParam name string required The name of the tax. Example: Tax 1
+     * @bodyParam percent number required The percent value. Example: 15.5
+     * @bodyParam date date optional The date of the tax. Example: 2024-01-01
+     * @bodyParam active boolean optional The status of the tax. Defaults to true. Example: true
+     */
+    public function save(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'name'    => 'required|max:35',
+            'percent' => 'required|regex:/^[0-9]+(\.[0-9][0-9]?)?$/',
+            'date'    => 'sometimes|date',
+        ], $this->custom_message());
+
+        if ($validator->fails()) {
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 400,
+                'message' => __('Incorrect Params'),
+                'data'    => $validator->errors()->getMessages(),
+            ];
+            return response()->json($response);
+        }
+        try {
+            $data = [
+                'name'    => $request->input('name'),
+                'percent' => $request->input('percent'),
+                'date'    => $request->input('date'),
+            ];
+            $tax = $this->TaxRepo->store($data);
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Tax saved correctly'),
+                'data'    => $tax,
+            ];
+            return response()->json($response, 200);
+        } catch (\Exception $ex) {
+            Log::error($ex);
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+
+    /**
+     * @group Tax
+     * Put
+     *
+     * update
+     * @urlParam id integer required The ID of the tax. Example: 1
+     * @bodyParam name string optional The name of the tax. Example: Tax x
+     * @bodyParam percent number optional The percent value. Example: 20
+     * @bodyParam date date optional The date of the tax. Example: 2024-01-01
+     * @bodyParam active boolean optional The status of the tax. Example: true
+     */
+    public function update(Request $request, $id)
+    {
+        $tax = $this->TaxRepo->find($id);
+        if (isset($tax->id)) {
+            $data = [];
+            if ($request->input('name')) { $data['name'] = $request->input('name'); }
+            if ($request->input('percent')) { $data['percent'] = $request->input('percent'); }
+            if ($request->input('date')) { $data['date'] = $request->input('date'); }
+            if ($request->has('active')) { $data['active'] = $request->input('active'); }
+            $tax = $this->TaxRepo->update($tax, $data);
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Tax updated'),
+                'data'    => $tax,
+            ];
+            return response()->json($response, 200);
+        }
+        $response = [
+            'status'  => 'FAILED',
+            'code'    => 500,
+            'message' => __('Tax dont exists') . '.',
+        ];
+        return response()->json($response, 500);
+    }
+
+    /**
+     * @group Tax
+     * Delete
+     * @urlParam id integer required The ID of the tax. Example: 1
+     *
+     * delete
+     */
+    public function delete(Request $request, $id)
+    {
+        try {
+            if ($this->TaxRepo->find($id)) {
+                $tax = $this->TaxRepo->find($id);
+                $tax = $this->TaxRepo->delete($tax);
+                $response = [
+                    'status'  => 'OK',
+                    'code'    => 200,
+                    'message' => __('Tax Deleted Successfully'),
+                    'data'    => $tax,
+                ];
+                return response()->json($response, 200);
+            } else {
+                $response = [
+                    'status'  => 'OK',
+                    'code'    => 404,
+                    'message' => __('Tax not Found'),
+                ];
+                return response()->json($response, 200);
+            }
+        } catch (\Exception $ex) {
+            Log::error($ex);
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+
+    /**
+     * @group Tax
+     * Patch
+     * @urlParam id integer required The ID of the tax. Example: 1
+     *
+     * change_status
+     */
+    public function change_status(Request $request, $id)
+    {
+        $tax = $this->TaxRepo->find($id);
+        if (isset($tax->active)) {
+            $data = ['active' => $tax->active ? 0 : 1];
+            $tax = $this->TaxRepo->update($tax, $data);
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Status Tax updated'),
+                'data'    => $tax,
+            ];
+            return response()->json($response, 200);
+        }
+        $response = [
+            'status'  => 'FAILED',
+            'code'    => 500,
+            'message' => __('Tax does not exist') . '.',
+        ];
+        return response()->json($response, 500);
+    }
+
+    /**
+     * @group Tax
+     * Get
+     *
+     * withTrashed
+     */
+    public function withTrashed()
+    {
+        try {
+            $tax = $this->TaxRepo->withTrashed();
+            $response = [
+                'status'  => 'OK',
+                'code'    => 200,
+                'message' => __('Data Obtained Correctly'),
+                'data'    => $tax,
+            ];
+            return response()->json($response, 200);
+        } catch (\Exception $ex) {
+            Log::error($ex);
+            $response = [
+                'status'  => 'FAILED',
+                'code'    => 500,
+                'message' => __('An error has occurred') . '.',
+            ];
+            return response()->json($response, 500);
+        }
+    }
+
+    public function custom_message()
+    {
+        return [
+            'name.required' => __('The name is required'),
+            'percent.required' => __('The percent is required'),
+        ];
+    }
+}

--- a/app/Models/Entities/Tax.php
+++ b/app/Models/Entities/Tax.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models\Entities;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Tax extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'name',
+        'percent',
+        'active',
+        'date',
+    ];
+
+    protected $casts = [
+        'date' => 'datetime:Y-m-d',
+    ];
+
+    protected static function newFactory()
+    {
+        return \Database\Factories\TaxFactory::new();
+    }
+}

--- a/app/Models/Repositories/TaxRepo.php
+++ b/app/Models/Repositories/TaxRepo.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models\Repositories;
+
+use App\Models\Entities\Tax;
+
+class TaxRepo
+{
+    public function all()
+    {
+        return Tax::all();
+    }
+
+    public function allActive()
+    {
+        return Tax::where('active', 1)->get();
+    }
+
+    public function find($id)
+    {
+        return Tax::find($id);
+    }
+
+    public function store(array $data)
+    {
+        return Tax::create($data);
+    }
+
+    public function update(Tax $tax, array $data)
+    {
+        $tax->update($data);
+        return $tax;
+    }
+
+    public function delete(Tax $tax)
+    {
+        return $tax->delete();
+    }
+
+    public function withTrashed()
+    {
+        return Tax::withTrashed()->get();
+    }
+}

--- a/database/factories/TaxFactory.php
+++ b/database/factories/TaxFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Entities\Tax;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TaxFactory extends Factory
+{
+    protected $model = Tax::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+            'percent' => $this->faker->randomFloat(2, 0, 100),
+            'active' => $this->faker->boolean(90),
+            'date' => $this->faker->date(),
+        ];
+    }
+}

--- a/database/migrations/2025_07_17_000000_create_taxes_table.php
+++ b/database/migrations/2025_07_17_000000_create_taxes_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('taxes', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 35);
+            $table->decimal('percent', 10, 2);
+            $table->boolean('active')->default(true);
+            $table->date('date')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('taxes');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,6 +21,7 @@ class DatabaseSeeder extends Seeder
             ProviderSeeder::class,
             AccountSeeder::class,
             RateSeeder::class,
+            TaxSeeder::class,
             TransactionSeeder::class,
         ]);
     }

--- a/database/seeders/TaxSeeder.php
+++ b/database/seeders/TaxSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Entities\Tax;
+
+class TaxSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Tax::updateOrCreate(
+            ['name' => 'IGTF'],
+            ['percent' => 3.00, 'active' => true]
+        );
+
+        Tax::updateOrCreate(
+            ['name' => 'Contribuyente Especial'],
+            ['percent' => 0, 'active' => true]
+        );
+
+        Tax::updateOrCreate(
+            ['name' => 'IVA'],
+            ['percent' => 16.00, 'active' => true]
+        );
+
+        Tax::factory()->count(10)->create();
+    }
+}

--- a/routes/api/taxes.php
+++ b/routes/api/taxes.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\TaxController;
+
+Route::group([
+    'middleware' => ['api'],
+    'prefix'     => 'taxes',
+], function () {
+    //Tax ROUTES
+    Route::post('/', [TaxController::class, 'save']);
+    Route::get('/{id}', [TaxController::class, 'find']);
+    Route::put('/{id}', [TaxController::class, 'update']);
+    Route::get('/', [TaxController::class, 'all']);
+    Route::patch('/{id}/status', [TaxController::class, 'change_status']);
+    Route::get('/active', [TaxController::class, 'allActive']);
+    Route::delete('/{id}', [TaxController::class, 'delete']);
+    Route::get('/all', [TaxController::class, 'withTrashed']);
+});


### PR DESCRIPTION
## Summary
- insert IGTF, Contribuyente Especial and 16% IVA in `TaxSeeder`
- keep factory created taxes

## Testing
- `composer install --no-interaction`
- `php artisan key:generate --ansi`
- `php artisan test` *(fails: 5 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6882eb034998832daf5618227bf5b47e