### PR TITLE
Add dashboard summary service and endpoints

### DIFF
--- a/app/Http/Controllers/Api/DashboardController.php
+++ b/app/Http/Controllers/Api/DashboardController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\DashboardService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DashboardController extends Controller
+{
+    public function __construct(private readonly DashboardService $dashboardService)
+    {
+    }
+
+    /**
+     * Administrative dashboard summary (requires admin role).
+     */
+    public function adminSummary(): JsonResponse
+    {
+        return response()->json($this->dashboardService->getAdminSummary());
+    }
+
+    /**
+     * Dashboard summary for the authenticated user.
+     */
+    public function userSummary(Request $request): JsonResponse
+    {
+        $filters = array_filter([
+            'from' => $request->query('from') ?? $request->query('date_from'),
+            'to' => $request->query('to') ?? $request->query('date_to'),
+        ]);
+
+        return response()->json(
+            $this->dashboardService->getUserSummary($request->user(), $filters)
+        );
+    }
+}

--- a/app/Services/DashboardService.php
+++ b/app/Services/DashboardService.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Entities\Account;
+use App\Models\Entities\Transaction;
+use App\Models\Entities\TransactionType;
+use App\Models\Role;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+class DashboardService
+{
+    /**
+     * Cache for transaction type ids resolved by slug.
+     */
+    protected array $transactionTypeIds = [];
+
+    /**
+     * Build a summary tailored for administrative dashboards.
+     */
+    public function getAdminSummary(): array
+    {
+        $totalUsers = User::count();
+        $activeUsers = User::where('active', 1)->count();
+        $inactiveUsers = $totalUsers - $activeUsers;
+
+        $totalAccounts = Account::count();
+        $activeAccounts = Account::where('active', 1)->count();
+
+        $totalTransactions = Transaction::count();
+        $activeTransactions = Transaction::where('active', 1)->count();
+
+        $financialQuery = Transaction::query()
+            ->where('active', 1)
+            ->where(function (Builder $q) {
+                $q->where('include_in_balance', 1)
+                    ->orWhereNull('include_in_balance');
+            });
+
+        $incomeTotal = $this->sumByType(clone $financialQuery, 'income');
+        $expenseTotalSigned = $this->sumByType(clone $financialQuery, 'expense');
+        $expenseTotal = abs((float) $expenseTotalSigned);
+        $netCashflow = (float) $incomeTotal + (float) $expenseTotalSigned;
+
+        $activeAccountBalances = Account::where('active', 1)->get(['balance_cached', 'initial']);
+        $totalBalance = $activeAccountBalances->sum(function (Account $account) {
+            $cached = $account->balance_cached;
+            if ($cached === null) {
+                return (float) ($account->initial ?? 0);
+            }
+            return (float) $cached;
+        });
+
+        $latestUsers = User::with('role:id,name,slug')
+            ->orderByDesc('created_at')
+            ->limit(5)
+            ->get(['id', 'name', 'email', 'created_at', 'active', 'role_id'])
+            ->map(function (User $user) {
+                return [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'active' => (bool) $user->active,
+                    'created_at' => optional($user->created_at)->toDateTimeString(),
+                    'role' => $user->role ? [
+                        'id' => $user->role->id,
+                        'name' => $user->role->name,
+                        'slug' => $user->role->slug,
+                    ] : null,
+                ];
+            })
+            ->all();
+
+        $usersByRole = Role::withCount('users')
+            ->get(['id', 'name', 'slug'])
+            ->map(function (Role $role) {
+                return [
+                    'id' => $role->id,
+                    'name' => $role->name,
+                    'slug' => $role->slug,
+                    'total' => (int) $role->users_count,
+                ];
+            })
+            ->all();
+
+        return [
+            'summary' => [
+                'totals' => [
+                    'users' => [
+                        'total' => (int) $totalUsers,
+                        'active' => (int) $activeUsers,
+                        'inactive' => (int) $inactiveUsers,
+                    ],
+                    'accounts' => [
+                        'total' => (int) $totalAccounts,
+                        'active' => (int) $activeAccounts,
+                    ],
+                    'transactions' => [
+                        'total' => (int) $totalTransactions,
+                        'active' => (int) $activeTransactions,
+                    ],
+                ],
+                'financials' => [
+                    'income' => round((float) $incomeTotal, 2),
+                    'expense' => round($expenseTotal, 2),
+                    'net_cashflow' => round($netCashflow, 2),
+                    'total_balance' => round((float) $totalBalance, 2),
+                ],
+                'users_by_role' => $usersByRole,
+                'latest_users' => $latestUsers,
+            ],
+        ];
+    }
+
+    /**
+     * Build a summary focused on a single authenticated user.
+     */
+    public function getUserSummary(User $user, array $filters = []): array
+    {
+        $accountIds = $user->accounts()->pluck('accounts.id')->map(fn ($id) => (int) $id)->unique()->values()->all();
+
+        $accountsCollection = !empty($accountIds)
+            ? Account::with('currency:id,code,name,symbol')
+                ->whereIn('id', $accountIds)
+                ->orderBy('name')
+                ->get(['id', 'name', 'currency_id', 'balance_cached', 'initial', 'active'])
+            : collect();
+
+        $accountsList = $accountsCollection->map(function (Account $account) {
+            $balance = $account->balance_cached !== null
+                ? (float) $account->balance_cached
+                : (float) ($account->initial ?? 0);
+
+            return [
+                'id' => $account->id,
+                'name' => $account->name,
+                'balance' => round($balance, 2),
+                'active' => (bool) $account->active,
+                'currency' => $account->currency ? [
+                    'id' => $account->currency->id,
+                    'code' => $account->currency->code,
+                    'name' => $account->currency->name,
+                    'symbol' => $account->currency->symbol,
+                ] : null,
+            ];
+        });
+
+        $totalBalance = $accountsList->sum(fn (array $account) => $account['balance']);
+        $activeAccountCount = $accountsList->filter(fn (array $account) => $account['active'])->count();
+
+        $balancesByCurrency = $accountsCollection
+            ->groupBy('currency_id')
+            ->map(function (Collection $group) {
+                $currency = $group->first()->currency;
+                $sum = $group->sum(function (Account $account) {
+                    if ($account->balance_cached !== null) {
+                        return (float) $account->balance_cached;
+                    }
+                    return (float) ($account->initial ?? 0);
+                });
+
+                return [
+                    'currency' => $currency ? [
+                        'id' => $currency->id,
+                        'code' => $currency->code,
+                        'name' => $currency->name,
+                        'symbol' => $currency->symbol,
+                    ] : null,
+                    'total_balance' => round((float) $sum, 2),
+                ];
+            })
+            ->values()
+            ->all();
+
+        $baseQuery = $this->buildUserTransactionQuery($accountIds, $filters, $user->id);
+
+        $incomeTotal = $this->sumByType(clone $baseQuery, 'income');
+        $expenseTotalSigned = $this->sumByType(clone $baseQuery, 'expense');
+        $expenseTotal = abs((float) $expenseTotalSigned);
+        $transactionCount = (clone $baseQuery)->count();
+        $netCashflow = (float) $incomeTotal + (float) $expenseTotalSigned;
+
+        $recentTransactions = (clone $baseQuery)
+            ->with('transactionType:id,name,slug')
+            ->orderByDesc('date')
+            ->limit(5)
+            ->get(['id', 'name', 'amount', 'date', 'transaction_type_id', 'account_id'])
+            ->map(function (Transaction $transaction) {
+                return [
+                    'id' => $transaction->id,
+                    'name' => $transaction->name,
+                    'amount' => (float) $transaction->amount,
+                    'date' => optional($transaction->date)->toDateTimeString(),
+                    'account_id' => $transaction->account_id,
+                    'type' => $transaction->transactionType ? [
+                        'id' => $transaction->transactionType->id,
+                        'name' => $transaction->transactionType->name,
+                        'slug' => $transaction->transactionType->slug,
+                    ] : null,
+                ];
+            })
+            ->all();
+
+        return [
+            'summary' => [
+                'accounts' => [
+                    'total' => count($accountIds),
+                    'active' => (int) $activeAccountCount,
+                    'total_balance' => round((float) $totalBalance, 2),
+                    'by_currency' => $balancesByCurrency,
+                    'list' => $accountsList->values()->all(),
+                ],
+                'financials' => [
+                    'income' => round((float) $incomeTotal, 2),
+                    'expense' => round($expenseTotal, 2),
+                    'net_cashflow' => round($netCashflow, 2),
+                    'transaction_count' => (int) $transactionCount,
+                ],
+                'recent_transactions' => $recentTransactions,
+            ],
+        ];
+    }
+
+    /**
+     * Sum helper by transaction type slug.
+     */
+    protected function sumByType(Builder $query, string $slug): float
+    {
+        $typeId = $this->getTransactionTypeId($slug);
+        if ($typeId === null) {
+            return 0.0;
+        }
+
+        return (float) $query->where('transaction_type_id', $typeId)->sum('amount');
+    }
+
+    /**
+     * Resolve transaction type ids by slug and cache them locally.
+     */
+    protected function getTransactionTypeId(string $slug): ?int
+    {
+        if (!array_key_exists($slug, $this->transactionTypeIds)) {
+            $this->transactionTypeIds[$slug] = TransactionType::where('slug', $slug)->value('id');
+        }
+
+        return $this->transactionTypeIds[$slug];
+    }
+
+    /**
+     * Build the base query used for user level aggregations.
+     */
+    protected function buildUserTransactionQuery(array $accountIds, array $filters, ?int $userId = null): Builder
+    {
+        $query = Transaction::query()
+            ->where('active', 1)
+            ->where(function (Builder $q) {
+                $q->where('include_in_balance', 1)
+                    ->orWhereNull('include_in_balance');
+            });
+
+        if (!empty($accountIds)) {
+            $query->where(function (Builder $q) use ($accountIds) {
+                $q->whereIn('account_id', $accountIds)
+                    ->orWhereHas('paymentTransactions', function (Builder $paymentQuery) use ($accountIds) {
+                        $paymentQuery->whereIn('account_id', $accountIds);
+                    });
+            });
+        } elseif ($userId) {
+            $query->where('user_id', $userId);
+        } else {
+            $query->whereRaw('1 = 0');
+        }
+
+        $this->applyDateFilters($query, $filters);
+
+        return $query;
+    }
+
+    /**
+     * Apply optional date range filters to a query.
+     */
+    protected function applyDateFilters(Builder $query, array $filters): void
+    {
+        $from = $filters['from'] ?? $filters['date_from'] ?? null;
+        $to = $filters['to'] ?? $filters['date_to'] ?? null;
+
+        if (!empty($from)) {
+            $fromDate = Carbon::parse($from)->startOfDay();
+            $query->where('date', '>=', $fromDate);
+        }
+
+        if (!empty($to)) {
+            $toDate = Carbon::parse($to)->endOfDay();
+            $query->where('date', '<=', $toDate);
+        }
+    }
+}

--- a/routes/api/dashboard.php
+++ b/routes/api/dashboard.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\DashboardController;
+
+Route::group([
+    'middleware' => ['api', 'auth:sanctum'],
+    'prefix' => 'dashboard',
+], function () {
+    Route::get('/user', [DashboardController::class, 'userSummary']);
+    Route::get('/admin', [DashboardController::class, 'adminSummary'])
+        ->middleware('App\\Http\\Middleware\\CheckRole:admin');
+});

--- a/tests/Feature/Api/DashboardSummaryTest.php
+++ b/tests/Feature/Api/DashboardSummaryTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Entities\Account;
+use App\Models\Entities\AccountType;
+use App\Models\Entities\Currency;
+use App\Models\Entities\Transaction;
+use App\Models\Entities\TransactionType;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class DashboardSummaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_dashboard_returns_global_totals(): void
+    {
+        $adminRole = Role::create(['name' => 'Administrator', 'slug' => 'admin']);
+        $userRole = Role::create(['name' => 'User', 'slug' => 'user']);
+
+        $admin = User::factory()->create(['role_id' => $adminRole->id]);
+        $user = User::factory()->create(['role_id' => $userRole->id]);
+
+        Sanctum::actingAs($admin, ['*']);
+
+        $currency = Currency::factory()->create(['code' => 'USD', 'symbol' => '$', 'name' => 'US Dollar']);
+        $accountType = AccountType::factory()->create(['name' => 'Checking']);
+
+        $primaryAccount = Account::factory()->create([
+            'name' => 'Main account',
+            'currency_id' => $currency->id,
+            'account_type_id' => $accountType->id,
+            'active' => 1,
+            'initial' => 1000,
+            'balance_cached' => 1000,
+        ]);
+
+        Account::factory()->create([
+            'name' => 'Inactive account',
+            'currency_id' => $currency->id,
+            'account_type_id' => $accountType->id,
+            'active' => 0,
+            'initial' => 500,
+            'balance_cached' => 500,
+        ]);
+
+        $incomeType = TransactionType::factory()->create(['name' => 'Income', 'slug' => 'income']);
+        $expenseType = TransactionType::factory()->create(['name' => 'Expense', 'slug' => 'expense']);
+
+        Transaction::factory()->create([
+            'name' => 'Salary',
+            'amount' => 200,
+            'account_id' => $primaryAccount->id,
+            'transaction_type_id' => $incomeType->id,
+            'user_id' => $user->id,
+            'include_in_balance' => 1,
+            'active' => 1,
+        ]);
+
+        Transaction::factory()->create([
+            'name' => 'Supplies',
+            'amount' => -50,
+            'account_id' => $primaryAccount->id,
+            'transaction_type_id' => $expenseType->id,
+            'user_id' => $user->id,
+            'include_in_balance' => 1,
+            'active' => 1,
+        ]);
+
+        $response = $this->getJson('/api/v1/dashboard/admin');
+
+        $response->assertOk();
+
+        $response->assertJson([
+            'summary' => [
+                'totals' => [
+                    'users' => ['total' => 2, 'active' => 2, 'inactive' => 0],
+                    'accounts' => ['total' => 2, 'active' => 1],
+                    'transactions' => ['total' => 2, 'active' => 2],
+                ],
+                'financials' => [
+                    'income' => 200.0,
+                    'expense' => 50.0,
+                    'net_cashflow' => 150.0,
+                    'total_balance' => 1000.0,
+                ],
+            ],
+        ]);
+
+        $this->assertCount(2, $response->json('summary.users_by_role'));
+        $this->assertNotEmpty($response->json('summary.latest_users'));
+    }
+
+    public function test_user_dashboard_returns_personal_summary(): void
+    {
+        $userRole = Role::create(['name' => 'User', 'slug' => 'user']);
+        $otherRole = Role::create(['name' => 'Other', 'slug' => 'other']);
+
+        $user = User::factory()->create(['role_id' => $userRole->id]);
+        $otherUser = User::factory()->create(['role_id' => $otherRole->id]);
+
+        Sanctum::actingAs($user, ['*']);
+
+        $usd = Currency::factory()->create(['code' => 'USD', 'symbol' => '$', 'name' => 'US Dollar']);
+        $eur = Currency::factory()->create(['code' => 'EUR', 'symbol' => '€', 'name' => 'Euro']);
+        $accountType = AccountType::factory()->create(['name' => 'Wallet']);
+
+        $accountUsd = Account::factory()->create([
+            'name' => 'USD Wallet',
+            'currency_id' => $usd->id,
+            'account_type_id' => $accountType->id,
+            'active' => 1,
+            'initial' => 1200.25,
+            'balance_cached' => 1200.25,
+        ]);
+
+        $accountEur = Account::factory()->create([
+            'name' => 'EUR Wallet',
+            'currency_id' => $eur->id,
+            'account_type_id' => $accountType->id,
+            'active' => 1,
+            'initial' => 350.75,
+            'balance_cached' => 350.75,
+        ]);
+
+        $user->accounts()->attach($accountUsd->id, ['is_owner' => 1]);
+        $user->accounts()->attach($accountEur->id, ['is_owner' => 0]);
+
+        $incomeType = TransactionType::factory()->create(['name' => 'Income', 'slug' => 'income']);
+        $expenseType = TransactionType::factory()->create(['name' => 'Expense', 'slug' => 'expense']);
+
+        Transaction::factory()->create([
+            'name' => 'Consulting',
+            'amount' => 300,
+            'account_id' => $accountUsd->id,
+            'transaction_type_id' => $incomeType->id,
+            'user_id' => $user->id,
+            'include_in_balance' => 1,
+            'active' => 1,
+            'date' => now()->subDay(),
+        ]);
+
+        Transaction::factory()->create([
+            'name' => 'Software subscription',
+            'amount' => -120.5,
+            'account_id' => $accountEur->id,
+            'transaction_type_id' => $expenseType->id,
+            'user_id' => $user->id,
+            'include_in_balance' => 1,
+            'active' => 1,
+            'date' => now(),
+        ]);
+
+        // Transaction excluded from balance
+        Transaction::factory()->create([
+            'name' => 'Transfer internal',
+            'amount' => -999,
+            'account_id' => $accountUsd->id,
+            'transaction_type_id' => $expenseType->id,
+            'user_id' => $user->id,
+            'include_in_balance' => 0,
+            'active' => 1,
+        ]);
+
+        // Transaction in another account (should not appear)
+        $otherAccount = Account::factory()->create([
+            'currency_id' => $usd->id,
+            'account_type_id' => $accountType->id,
+            'active' => 1,
+            'initial' => 75,
+            'balance_cached' => 75,
+        ]);
+
+        Transaction::factory()->create([
+            'name' => 'Other user income',
+            'amount' => 999,
+            'account_id' => $otherAccount->id,
+            'transaction_type_id' => $incomeType->id,
+            'user_id' => $otherUser->id,
+            'include_in_balance' => 1,
+            'active' => 1,
+        ]);
+
+        $response = $this->getJson('/api/v1/dashboard/user');
+
+        $response->assertOk();
+
+        $response->assertJson([
+            'summary' => [
+                'accounts' => [
+                    'total' => 2,
+                    'active' => 2,
+                    'total_balance' => 1551.0,
+                ],
+                'financials' => [
+                    'income' => 300.0,
+                    'expense' => 120.5,
+                    'net_cashflow' => 179.5,
+                    'transaction_count' => 2,
+                ],
+            ],
+        ]);
+
+        $this->assertCount(2, $response->json('summary.accounts.by_currency'));
+        $this->assertCount(2, $response->json('summary.recent_transactions'));
+        $this->assertEquals(-120.5, $response->json('summary.recent_transactions.0.amount'));
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `DashboardService` that aggregates administrative and user-facing metrics
- expose `/api/v1/dashboard/admin` and `/api/v1/dashboard/user` endpoints backed by the new controller and routes
- cover the new flows with feature tests that validate the aggregated payloads for admins and end users

## Testing
- `php artisan test --filter=DashboardSummaryTest` *(fails: vendor/autoload.php missing because composer install is blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68e2edb0e17c832284fa3a1770fa975b